### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/visualiser/tournament/test_forms.py
+++ b/visualiser/tournament/test_forms.py
@@ -277,7 +277,7 @@ class GamePlayersFormTest(TestCase):
         form = GamePlayersForm(the_round=self.r1)
         self.assertIn('game_id', form.fields)
 
-    def test_name_field(self):
+    def test_name_field_two(self):
         form = GamePlayersForm(the_round=self.r1)
         self.assertIn('name', form.fields)
 

--- a/visualiser/tournament/test_game_seeder.py
+++ b/visualiser/tournament/test_game_seeder.py
@@ -712,7 +712,7 @@ class GameSeederSeedingTest(unittest.TestCase):
         for g in r:
             self.assertNotEqual('A' in g, 'B' in g)
 
-    def test_seed_games_separate_dups_1(self):
+    def test_seed_games_separate_dups_1_two(self):
         s = create_seeder(num_players=18)
         dups = set(['A', 'B', 'C'])
         r = s.seed_games(players_doubling_up=dups)


### PR DESCRIPTION
Fixes #217.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

