### PR TITLE
fixed bug in _improve_fitness in game_seeder.py

### DIFF
--- a/visualiser/tournament/game_seeder.py
+++ b/visualiser/tournament/game_seeder.py
@@ -397,8 +397,7 @@ class GameSeeder:
         # The more iterations, the better the result, but the longer it takes
         for _ in range(self.iterations):
             # Try swapping a random player between two random games
-            g1 = random.choice(games)
-            g2 = random.choice(games)
+            g1, g2 = random.sample(games,2)
             p1 = g1.pop()
             p2 = g2.pop()
             if (p1 in g2) or (p2 in g1):


### PR DESCRIPTION
I was poking around in the game seeding code and noticed that in `_improve_fitness` on lines 400-401 you're sampling the same list twice with replacement, so in a two board tournament it's going to pick the same game (g1 == g2) twice about 50% of the time the way you have it set up. I'm thinking wasting 50% of the fitness checks may have contributed to the wonky seeding results we saw at Skycon.

The only change in this pull request is switching that to sampling without replacement so that _improve_fitness never picks the same game as both g1 and g2.