### PR TITLE
board_call settings tweaks

### DIFF
--- a/visualiser/.gitignore
+++ b/visualiser/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 db.sqlite3
+*.crt
+*.key

--- a/visualiser/tournament/forms.py
+++ b/visualiser/tournament/forms.py
@@ -1016,12 +1016,18 @@ class PlayerRoundForm(forms.Form):
     # We want all Players to be available to be chosen,
     # as this provides an easy way to add TournamentPlayers
     player = PlayerChoiceField(queryset=Player.objects.all())
-    present = forms.BooleanField(required=False, initial=False)
-    standby = forms.BooleanField(required=False, initial=False)
-    sandboxer = forms.BooleanField(required=False, initial=False)
+    present = forms.BooleanField(required=False,
+                                 initial=False,
+                                 widget=forms.CheckboxInput(attrs={'class': 'center-checkbox'}))
+    standby = forms.BooleanField(required=False,
+                                 initial=False,
+                                 widget=forms.CheckboxInput(attrs={'class': 'center-checkbox'}))
+    sandboxer = forms.BooleanField(required=False,
+                                   initial=False,
+                                   widget=forms.CheckboxInput(attrs={'class': 'center-checkbox'}))
     rounds_played = forms.IntegerField(required=False,
                                        disabled=True,
-                                       max_value=10,
+                                       widget=forms.TextInput(attrs={'class': 'readonly-look'}),
                                        min_value=0)
 
     def clean(self):

--- a/visualiser/tournament/templates/base.html
+++ b/visualiser/tournament/templates/base.html
@@ -11,6 +11,35 @@
       <meta http-equiv="refresh" content="{{ redirect_time }}; url={{ redirect_url }}"/>
     {% endif %}
     <title>{% block title %}{% trans "DipTV - Diplomacy Tournament Visualiser" %}{% endblock title %}</title>
+    
+    {% comment %}
+    readonly-look is to make the rounds_played count,
+    from PlayerRoundForm in forms.py, now formatted as text,
+    not look editable
+
+    TODO: everything inside this block extra_header
+          should really be in templates/rounds/board_call.html,
+          but when I tried to do a {% block %}{% endblock %} in
+          this file and then put everything in <style></style>
+          it didn't work and I'm not sure why.
+
+          in the meantime, these will only affect form fields
+          where they are explicitly set as an attribute. 
+    {% endcomment %}
+    <style>
+    .readonly-look:disabled {
+        border: none !important;
+        background: transparent !important;
+        padding-left: 0 !important;
+        color: inherit !important;
+        text-align: center !important;
+    }
+    .center-checkbox {
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
+    }
+   </style>
 </head>
 
 {% block style %}{% endblock style %}


### PR DESCRIPTION
Removed max_value=10 from PlayerRoundForm.rounds_played in forms.py, now only has min_value=0

Edited the IntegerField declaration for rounds_played to display as text that doesn't give the impression of being editable, and centered this text as well as the present/standby/sandboxer checkboxes. This required adding some CSS, which I wanted to put into board_call.html, but using the {% block %}{% endblock %} convention in base.html and board_call.html wasn't working so I placed this directly in base.html. Since you have to explicitly set these styles as an option on your form fields it won't affect anything other the four fields I modified, it's just organizationally not great to have this all defined in the main base.html.

Additionally, I added *.crt and *.key to the .gitignore (these are from having to use manage.py with runserver_plus to get the development server to run with https).

Issue #395